### PR TITLE
CI: Bust cache based on mix.lock contents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,8 @@ jobs:
           ~/.hex
           ~/.mix
           _build
-        key: ${{ matrix.otp }}-${{ matrix.elixir }}
+          deps
+        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
     - name: Install Dependencies
       run: |
         mix local.rebar --force


### PR DESCRIPTION
Mostly matches the cache official guide:
https://github.com/actions/cache/blob/main/examples.md#elixir---mix