### PR TITLE
Add draw utils

### DIFF
--- a/lib/utils/graph_state.ex
+++ b/lib/utils/graph_state.ex
@@ -1,11 +1,33 @@
 defmodule ScenicWidgets.GraphState do
-  @spec update_graph( Scenic.Scene.t(), fun() ) :: Scenic.Scene.t()
+  @moduledoc """
+  Facilitates the usage of a `%State{}` struct with a scene
+
+  Note: the `%State{}` struct should have at least a `:graph` attribute.
+
+  Example basic state module:
+
+      defmodule State do
+        @moduledoc false
+        defstruct [:graph]
+      end
+  """
+
+  @doc """
+  Updates and pushes the graph
+  """
+  @spec update_graph(Scenic.Scene.t(), fun()) :: Scenic.Scene.t()
   def update_graph(%Scenic.Scene{} = scene, fun) when is_function(fun, 1) do
     graph = fun.(scene.assigns.state.graph)
     assign_and_push_graph(scene, scene.assigns.state, graph)
   end
 
-  def assign_and_push_graph(scene, state, graph) do
+  @spec update_state(Scenic.Scene.t(), fun()) :: Scenic.Scene.t()
+  def update_state(%Scenic.Scene{} = scene, fun) when is_function(fun, 1) do
+    state = fun.(scene.assigns.state)
+    Scenic.Scene.assign(scene, :state, state)
+  end
+
+  def assign_and_push_graph(%Scenic.Scene{} = scene, state, graph) do
     state = %{state | graph: graph}
 
     scene

--- a/lib/utils/graph_state.ex
+++ b/lib/utils/graph_state.ex
@@ -1,5 +1,6 @@
 defmodule ScenicWidgets.GraphState do
-  def update_graph(scene, fun) when is_function(fun, 1) do
+  @spec update_graph( Scenic.Scene.t(), fun() ) :: Scenic.Scene.t()
+  def update_graph(%Scenic.Scene{} = scene, fun) when is_function(fun, 1) do
     graph = fun.(scene.assigns.state.graph)
     assign_and_push_graph(scene, scene.assigns.state, graph)
   end

--- a/lib/utils/graph_state.ex
+++ b/lib/utils/graph_state.ex
@@ -1,0 +1,14 @@
+defmodule ScenicWidgets.GraphState do
+  def update_graph(scene, fun) when is_function(fun, 1) do
+    graph = fun.(scene.assigns.state.graph)
+    assign_and_push_graph(scene, scene.assigns.state, graph)
+  end
+
+  def assign_and_push_graph(scene, state, graph) do
+    state = %{state | graph: graph}
+
+    scene
+    |> Scenic.Scene.assign(:state, state)
+    |> Scenic.Scene.push_graph(graph)
+  end
+end

--- a/lib/utils/redraw.ex
+++ b/lib/utils/redraw.ex
@@ -1,4 +1,17 @@
 defmodule ScenicWidgets.Redraw do
+  @moduledoc """
+  Simple module to assist in redrawing a simple scenic component
+
+  Drawback is that the id needs to be specified twice. Compare with `ScenicWidgets.Redraw2`
+
+  Example:
+
+      graph
+      |> ScenicWidgets.Redraw.draw(:my_text, fn _g ->
+        text = "This the some text to display"
+        {Primitive.Text, text, id: :my_text, t: {90, 150}, font_size: 10, text_align: :left}
+      end)
+  """
   alias Scenic.Graph
 
   def draw(graph, id, fun) do
@@ -13,8 +26,8 @@ defmodule ScenicWidgets.Redraw do
         fun.(graph)
 
       [_] ->
-        Graph.modify(graph, id, fn graph ->
-          fun.(graph)
+        Graph.modify(graph, id, fn graph_or_primitive ->
+          fun.(graph_or_primitive)
         end)
     end
   end

--- a/lib/utils/redraw.ex
+++ b/lib/utils/redraw.ex
@@ -1,0 +1,21 @@
+defmodule ScenicWidgets.Redraw do
+  alias Scenic.Graph
+
+  def draw(graph, id, fun) do
+    case Graph.get(graph, id) do
+      [] ->
+        fun.(graph)
+
+      # Work around not being able to modify a group primitive
+      # Bug: https://github.com/boydm/scenic/issues/27
+      [%{module: Scenic.Primitive.Group}] ->
+        graph = Graph.delete(graph, id)
+        fun.(graph)
+
+      [_] ->
+        Graph.modify(graph, id, fn graph ->
+          fun.(graph)
+        end)
+    end
+  end
+end

--- a/lib/utils/redraw2.ex
+++ b/lib/utils/redraw2.ex
@@ -1,0 +1,81 @@
+defmodule ScenicWidgets.Redraw2 do
+  @moduledoc """
+  Version of `ScenicWidgets.Redraw` that makes it easier to update a component in place
+
+  But the drawback is that the code becomes less legible
+
+  Example:
+
+      graph
+      |> ScenicWidgets.Redraw2.draw(:some_text, fn _g ->
+        text = "This the some text to display"
+        {Primitive.Text, text, t: {90, 150}, font_size: 10, text_align: :left}
+      end)
+  """
+  alias Scenic.Graph
+  alias Scenic.Primitive
+
+  def rectangle(%Graph{} = g, data, opts) do
+    add_to_graph(g, Primitive.Rectangle, data, opts)
+  end
+
+  def rectangle(%Primitive{module: Primitive.Rectangle} = p, data, opts) do
+    modify(p, data, opts)
+  end
+
+  def draw(graph, id, fun) do
+    case Graph.get(graph, id) do
+      [] ->
+        {mod, params, opts} = fun.(graph)
+        opts = Keyword.put_new(opts, :id, id)
+        add_to_graph(graph, mod, params, opts)
+
+      # Work around not being able to modify a group primitive
+      # Bug: https://github.com/boydm/scenic/issues/27
+      [%{module: Scenic.Primitive.Group}] ->
+        graph = Graph.delete(graph, id)
+        {mod, params, opts} = fun.(graph)
+        add_to_graph(graph, mod, params, opts)
+
+      [_primitive] ->
+        Graph.modify(graph, id, fn primitive ->
+          {_mod, params, opts} = fun.(primitive)
+          modify(primitive, params, opts)
+        end)
+    end
+  end
+
+  # Copied from Scenic:
+  # https://github.com/boydm/scenic/blob/94679b1ab50834e20b94ca11bc0c5645bf0c909e/lib/scenic/components.ex#L696
+  defp modify(%Primitive{module: Primitive.Component, data: {mod, _, id}} = p, data, options) do
+    data =
+      case mod.validate(data) do
+        {:ok, data} -> data
+        {:error, msg} -> raise msg
+      end
+
+    Primitive.put(p, {mod, data, id}, options)
+  end
+
+  # Copied from Scenic:
+  # https://github.com/boydm/scenic/blob/9314020b2962e38bea871e8e1f59cd273dfe0af0/lib/scenic/primitives.ex#L1467
+  defp modify(%Primitive{module: mod} = p, data, opts) do
+    data =
+      case mod.validate(data) do
+        {:ok, data} -> data
+        {:error, error} -> raise Exception.message(error)
+      end
+
+    Primitive.put(p, data, opts)
+  end
+
+  defp add_to_graph(%Graph{} = g, mod, data, opts) do
+    data =
+      case mod.validate(data) do
+        {:ok, data} -> data
+        {:error, error} -> raise Exception.message(error)
+      end
+
+    mod.add_to_graph(g, data, opts)
+  end
+end


### PR DESCRIPTION
Adds two ways to redraw components/primitives, `Redraw` and `Redraw2`. `Redraw` is simpler to use (and lets you use the Scenic primitive functions) but it doesn't allow you to update components in place as easily.