### PR TITLE
Various suggested improvements to the MenuBar

### DIFF
--- a/lib/components/menu_bar/README.md
+++ b/lib/components/menu_bar/README.md
@@ -114,7 +114,7 @@ the function-capture syntax native to Elixir, e.g.
 
 ## Dynamically changing the menu-map
 
-The MenuBar can have it's contents updated at any time - this is expecially
+The MenuBar can have it's contents updated at any time - this is especially
 useful for making context-aware menus, e.g. if one of your sub-menus showed
 a list of open files (as is the case for [Flamelex](https://github.com/JediLuke/flamelex)) then opening
 a new file should update the menu-bar to show this new file (which Flamelex does!)
@@ -147,29 +147,32 @@ vp_width = 1000         # fetch the viewport width from Scenic
 menu_bar_height = 40    # pick whatever you like
 {:fixed, 220}           # sets how wide the columns of the menus are
 
+# Note: IBM Plex Mono is open source and can be downloaded at:
+# https://fonts.google.com/specimen/IBM+Plex+Mono
 {:ok, ibm_plex_mono_metrics} =
-    TruetypeMetrics.load("./assets/fonts/IBMPlexMono-Regular.ttf")
+  TruetypeMetrics.load("./assets/fonts/IBMPlexMono-Regular.ttf")
 
 font = %{
-    name: :ibm_plex_mono,   # pass in the custom font here
-    size: 36,               # This is the size of the font for the main MenuBar (not sub-menus)
-    metrics: ibm_plex_mono_metrics      # pass in the FontMetrics we calculated above
+  name: :ibm_plex_mono,   # pass in the custom font here
+  size: 36,               # This is the size of the font for the main MenuBar (not sub-menus)
+  metrics: ibm_plex_mono_metrics      # pass in the FontMetrics we calculated above
 }
 
 sub_menu_options = %{
-    height: 40,         # the block-height of sub-menu item rectangles
-    font_size: 22       # font-size to use in the sub-menus
+  height: 40,         # the block-height of sub-menu item rectangles
+  font_size: 22       # font-size to use in the sub-menus
 }
 
 Scenic.Graph.build()
 |> ScenicWidgets.MenuBar.add_to_graph( %{
-        frame: ScenicWidgets.Core.Structs.Frame.new(
-            pin: {0, 0},
-            size: {vp_width, menu_bar_height}),
-        menu_map: menu_map,
-        item_width: {:fixed, 180},
-        font: menubar_font,
-        sub_menu: sub_menu_options
+  frame: ScenicWidgets.Core.Structs.Frame.new(
+    pin: {0, 0},
+    size: {vp_width, menu_bar_height}
+  ),
+  menu_map: menu_map,
+  item_width: {:fixed, 180},
+  font: menubar_font,
+  sub_menu: sub_menu_options
 })
 ```
 
@@ -178,12 +181,13 @@ keep the default size, is to pass in the font's name (as an atom):
 
 ```
 Scenic.Graph.build()
-|> ScenicWidgets.MenuBar.add_to_graph( %{
-        frame: ScenicWidgets.Core.Structs.Frame.new(
-            pin: {0, 0},
-            size: {vp_width, menu_bar_height}),
-        menu_map: menu_map(),
-        font: :ibm_plex_mono
+|> ScenicWidgets.MenuBar.add_to_graph(%{
+  frame: ScenicWidgets.Core.Structs.Frame.new(
+    pin: {0, 0},
+    size: {vp_width, menu_bar_height}
+  ),
+  menu_map: menu_map(),
+  font: :ibm_plex_mono
 })
 ```
 
@@ -196,7 +200,7 @@ the function defined against that item in the menu-map.
 Press escape to close the menu from the keyboard. Move the mouse below
 the longest open sub-menu to automatically close the menu.
 
-Right now the MenuBar doesn't recognise when you move the mouse horizontally
+Right now the MenuBar doesn't recognize when you move the mouse horizontally
 away from a sub-menu, so it stays open. This is technically a bug, but
 surprisingly it is no issue in practice (at least for me).
 
@@ -212,18 +216,17 @@ Imagine we have this module:
 
 ```
 defmodule ArityZeroDemo do
+  def custom_fn do
+    IO.puts("You called the custom fn!")
+  end
 
-    def custom_fn do
-        IO.puts "You called the custom fn!"
-    end
+  def my_fave_fn do
+    IO.puts("This is my favourite function...")
+  end
 
-    def my_fave_fn do
-        IO.puts "This is my favourite function..."
-    end
-
-    def arity_one(x) do
-        IO.puts "You passed in: #{inspect x}"
-    end
+  def arity_one(x) do
+    IO.puts("You passed in: #{inspect x}")
+  end
 end
 ```
 
@@ -249,27 +252,23 @@ Here is a tiny example:
 
 ```
 defmodule Flamelex.API do
-
-    def one_func, do: IO.puts "Clicked 1"
-    def two_func, do: IO.puts "Clicked 2"
+  def one_func, do: IO.puts "Clicked 1"
+  def two_func, do: IO.puts "Clicked 2"
 end
 
 defmodule Flamelex.API.FirstSub do
-
-    def one_func, do: IO.puts "Clicked FirstSub - 1"
-    def two_func, do: IO.puts "Clicked FirstSub - 2"
+  def one_func, do: IO.puts "Clicked FirstSub - 1"
+  def two_func, do: IO.puts "Clicked FirstSub - 2"
 end
 
 defmodule Flamelex.API.SecondSub do
-
-    def one_func, do: IO.puts "Clicked SecondSub - 1"
-    def two_func, do: IO.puts "Clicked SecondSub - 2"
+  def one_func, do: IO.puts "Clicked SecondSub - 1"
+  def two_func, do: IO.puts "Clicked SecondSub - 2"
 end
 
 defmodule Flamelex.API.SecondSub.Nested do
-
-    def one_func, do: IO.puts "Clicked SecondSub.Nested - 1"
-    def two_func, do: IO.puts "Clicked SecondSub.Nested - 2"
+  def one_func, do: IO.puts "Clicked SecondSub.Nested - 1"
+  def two_func, do: IO.puts "Clicked SecondSub.Nested - 2"
 end
 ```
 
@@ -278,14 +277,14 @@ To generate a menu tree which looks like this:
 ```
 API
 - FirstSub
-    - one_func
-    - two_func
+  - one_func
+  - two_func
 - SecondSub
-    - Nested
-        - one_func
-        - two_func
+  - Nested
     - one_func
     - two_func
+  - one_func
+  - two_func
 - one_func
 - two_func
 ```

--- a/lib/components/menu_bar/README.md
+++ b/lib/components/menu_bar/README.md
@@ -14,22 +14,23 @@ Setting `pin: {0, 0}` places the MenuBar in the top-left corner.
 vp_width = 800 # need to pass in the ViewPort width
 
 Scenic.Graph.build()
-|> ScenicWidgets.MenuBar.add_to_graph( %{
-        frame: ScenicWidgets.Core.Structs.Frame.new(
-            pin: {0, 0},
-            size: {vp_width, _menu_bar_height = 60}),
-        menu_map: [
-            {:sub_menu, "Ice Cream", [
-                {"Chocolate", fn -> IO.puts "clicked: `Chocolate`!" end},
-                {"Vanilla", fn -> IO.puts "clicked: `Vanilla`!" end}
-            ]},
-            {:sub_menu, "Ninja Turtles", [
-                {"Leonardo", fn -> IO.puts "clicked: `Leonardo`!" end},
-                {"Raphael", fn -> IO.puts "clicked: `Raphael`!" end},
-                {"Donatello", fn -> IO.puts "clicked: `Donatello`!" end},
-                {"Michelangelo", fn -> IO.puts "clicked: `Michelangelo`!" end},
-            ]}
-        ]
+|> ScenicWidgets.MenuBar.add_to_graph(%{
+  frame: ScenicWidgets.Core.Structs.Frame.new(
+    pin: {0, 0},
+    size: {vp_width, _menu_bar_height = 60}
+  ),
+  menu_map: [
+    {:sub_menu, "Ice Cream", [
+      {"Chocolate", fn -> IO.puts "clicked: `Chocolate`!" end},
+      {"Vanilla", fn -> IO.puts "clicked: `Vanilla`!" end}
+    ]},
+    {:sub_menu, "Ninja Turtles", [
+      {"Leonardo", fn -> IO.puts "clicked: `Leonardo`!" end},
+      {"Raphael", fn -> IO.puts "clicked: `Raphael`!" end},
+      {"Donatello", fn -> IO.puts "clicked: `Donatello`!" end},
+      {"Michelangelo", fn -> IO.puts "clicked: `Michelangelo`!" end},
+    ]}
+  ]
 })
 ```
 
@@ -48,29 +49,29 @@ nesting this format, for example:
 
 ```
 def calc_menu_map() do
-    [
-        {:sub_menu, "Test Menu", [
-            {"Item One", fn -> IO.puts "clicked: `Item One`!" end},
-            {"Item Two", fn -> IO.puts "clicked: `Item Two`!" end},
-            {:sub_menu, "Dropdown", [
-                {"Dropdown 1", fn -> IO.puts "clicked: `Dropdown 1`!" end},
-                {"Dropdown 2", fn -> IO.puts "clicked: `Dropdown 2`!" end}
-            ]},
-            {"Item Three", fn -> IO.puts "clicked: `Item Three`!" end},
-            {:sub_menu, "Another Menu", [
-                {"Dropdown 1", fn -> IO.puts "clicked: `Dropdown 1`!" end},
-                {:sub_menu, "Inner Menu", [
-                    {"Inner Menu 1", fn -> IO.puts "clicked: `Inner Menu 1`!" end},
-                    {"Inner Menu 2", fn -> IO.puts "clicked: `Inner Menu 2`!" end}
-                ]},
-                {"Dropdown 2", fn -> IO.puts "clicked: `Dropdown 2`!" end}
-            ]}
+  [
+    {:sub_menu, "Test Menu", [
+      {"Item One", fn -> IO.puts "clicked: `Item One`!" end},
+      {"Item Two", fn -> IO.puts "clicked: `Item Two`!" end},
+      {:sub_menu, "Dropdown", [
+        {"Dropdown 1", fn -> IO.puts "clicked: `Dropdown 1`!" end},
+        {"Dropdown 2", fn -> IO.puts "clicked: `Dropdown 2`!" end}
+      ]},
+      {"Item Three", fn -> IO.puts "clicked: `Item Three`!" end},
+      {:sub_menu, "Another Menu", [
+        {"Dropdown 1", fn -> IO.puts "clicked: `Dropdown 1`!" end},
+        {:sub_menu, "Inner Menu", [
+          {"Inner Menu 1", fn -> IO.puts "clicked: `Inner Menu 1`!" end},
+          {"Inner Menu 2", fn -> IO.puts "clicked: `Inner Menu 2`!" end}
         ]},
-        {:sub_menu, "Ice Cream", [
-            {"Chocolate", fn -> IO.puts "clicked: `Chocolate`!" end},
-            {"Vanilla", fn -> IO.puts "clicked: `Vanilla`!" end}
-        ]}
-    ]
+        {"Dropdown 2", fn -> IO.puts "clicked: `Dropdown 2`!" end}
+      ]}
+    ]},
+    {:sub_menu, "Ice Cream", [
+      {"Chocolate", fn -> IO.puts "clicked: `Chocolate`!" end},
+      {"Vanilla", fn -> IO.puts "clicked: `Vanilla`!" end}
+    ]}
+  ]
 end
 ```
 
@@ -91,14 +92,14 @@ is supposed to react to the button click, e.g.
 
 ```
 {:sub_menu, "Ice Cream", [
-        {"Chocolate", fn ->
-            IO.puts "clicked: `Chocolate`!"
-            send IceCreamManager, {:clicked, :chocolate}
-        end},
-        {"Vanilla", fn ->
-            IO.puts "clicked: `Vanilla`!"
-            send IceCreamManager, {:clicked, :chocolate}
-        end}
+  {"Chocolate", fn ->
+    IO.puts "clicked: `Chocolate`!"
+    send IceCreamManager, {:clicked, :chocolate}
+  end},
+  {"Vanilla", fn ->
+    IO.puts "clicked: `Vanilla`!"
+    send IceCreamManager, {:clicked, :chocolate}
+  end}
 ]}
 ```
 

--- a/lib/components/menu_bar/README.md
+++ b/lib/components/menu_bar/README.md
@@ -292,7 +292,7 @@ API
 
 We can define a sub-menu as follows:
 
-```
+```elixir
 {:sub_menu, "API", ScenicWidgets.MenuBar.modules_and_zero_arity_functions("Elixir.Flamelex.API")}
 ```
 

--- a/lib/components/menu_bar/README.md
+++ b/lib/components/menu_bar/README.md
@@ -10,7 +10,7 @@ Demo video (5 minutes): https://youtu.be/k1kiCL9oMf4
 This is an example of all the code required to render a MenuBar.
 Setting `pin: {0, 0}` places the MenuBar in the top-left corner.
 
-```
+```elixir
 vp_width = 800 # need to pass in the ViewPort width
 
 Scenic.Graph.build()
@@ -47,7 +47,7 @@ shown for this sub-menu and the item list is another list of exactly
 the same format. You can define sub-menus inside sub-menus just by
 nesting this format, for example:
 
-```
+```elixir
 def calc_menu_map() do
   [
     {:sub_menu, "Test Menu", [
@@ -90,7 +90,7 @@ is simply returning some data, this will basically do nothing. The best
 way is to simply send a message to whatever other part of your software
 is supposed to react to the button click, e.g.
 
-```
+```elixir
 {:sub_menu, "Ice Cream", [
   {"Chocolate", fn ->
     IO.puts "clicked: `Chocolate`!"
@@ -109,7 +109,7 @@ and is not necessary, just sometimes useful.
 To call a zero-arity defined in a different module, simply use
 the function-capture syntax native to Elixir, e.g.
 
-```
+```elixir
 {"Strawberry", &IceCream.Flavour.strawberry/0}
 ```
 
@@ -122,7 +122,7 @@ a new file should update the menu-bar to show this new file (which Flamelex does
 
 To update the menu map, simply cast to the component with a new MenuMap.
 
-```
+```elixir
 # the Component is automatically registered with this name
 GenServer.cast(ScenicWidgets.MenuBar, {:put_menu_map, new_menu_map})
 
@@ -143,7 +143,7 @@ by passing them in as arguments when creating the Graph.
 
 Here is an example of using all of the extended options
 
-```
+```elixir
 vp_width = 1000         # fetch the viewport width from Scenic
 menu_bar_height = 40    # pick whatever you like
 {:fixed, 220}           # sets how wide the columns of the menus are
@@ -180,7 +180,7 @@ Scenic.Graph.build()
 One shortcut, if you just want to use a custom font but are happy to
 keep the default size, is to pass in the font's name (as an atom):
 
-```
+```elixir
 Scenic.Graph.build()
 |> ScenicWidgets.MenuBar.add_to_graph(%{
   frame: ScenicWidgets.Core.Structs.Frame.new(
@@ -215,7 +215,7 @@ some tools for automatically generating them.
 
 Imagine we have this module:
 
-```
+```elixir
 defmodule ArityZeroDemo do
   def custom_fn do
     IO.puts("You called the custom fn!")
@@ -235,7 +235,7 @@ To automatically create a sub-menu of all the zero-arity functions
 in this module (it has to be the zero-arity functions, since there's
 no way of passing in extra arguments), you can do this:
 
-```
+```elixir
 {:sub_menu, "arity/0 demo", ScenicWidgets.MenuBar.zero_arity_functions(ArityZeroDemo)}
 ```
 
@@ -251,7 +251,7 @@ Well, we can!
 
 Here is a tiny example:
 
-```
+```elixir
 defmodule Flamelex.API do
   def one_func, do: IO.puts "Clicked 1"
   def two_func, do: IO.puts "Clicked 2"

--- a/lib/components/menu_bar/menu_bar.ex
+++ b/lib/components/menu_bar/menu_bar.ex
@@ -73,6 +73,11 @@ defmodule ScenicWidgets.MenuBar do
         font_name when is_atom(font_name) ->
           {:ok, {_type, custom_font_metrics}} = Scenic.Assets.Static.meta(font_name)
           %{name: font_name, metrics: custom_font_metrics, size: @default_top_line_font_size}
+
+        other ->
+          raise "MenuBar: Invalid font received. Should either be an atom representing a " <>
+                  "font name or a map with `:name`, `:size`, and optionally `:metrics`. " <>
+                  "(received: #{inspect(other, pretty: true)})"
       end
 
     init_sub_menu_opts =

--- a/lib/components/menu_bar/menu_map_maker.ex
+++ b/lib/components/menu_bar/menu_map_maker.ex
@@ -2,7 +2,7 @@ defmodule ScenicWidgets.MenuBar.MenuMapMaker do
   @doc """
   Return a list of all the zero-arity functions in a module, in
   the correctly formatted list of `{label, function}` tuples for
-  injecting into a GUI.Component.MenuBar menu-map.
+  injecting into a `ScenicWidgets.MenuBar` menu-map.
   """
   def zero_arity_functions("Elixir." <> module_name) when is_bitstring(module_name) do
     # NOTE: Because we automatically add Elixir. to the start of the module
@@ -45,7 +45,7 @@ defmodule ScenicWidgets.MenuBar.MenuMapMaker do
   convention for Elixir modules. Returns a correctly formatted list of
   sub-menus (in the form `{:sub_menu, label, menu}`) and zero-arity
   functions (in the form `{label, function}`) for building sub-menu trees
-  that can be injected into a GUI.Component.MenuBar menu-map.
+  that can be injected into a `ScenicWidgets.MenuBar` menu-map.
 
   To filter from the list of all possible modules, we have to give it
   a string which is what all the modules in the sub-menu tree start with,
@@ -94,7 +94,7 @@ defmodule ScenicWidgets.MenuBar.MenuMapMaker do
     # convert a list like ["Module", "By", "Luke"] to a string, "Module.By.Luke"
     module_name = Enum.reduce(top_item, fn x, acc -> acc <> "." <> x end)
 
-    # NOTE: It's this step which causes the recusrion to bottom-out.
+    # NOTE: It's this step which causes the recursion to bottom-out.
     # the increasing size of the sub-modules means we eventually
     # get an empty list when we filter on items which are a level deeper
     sub_modules =

--- a/lib/core/scenic_events_definitions.ex
+++ b/lib/core/scenic_events_definitions.ex
@@ -192,7 +192,7 @@ defmodule ScenicWidgets.ScenicEventsDefinitions do
       @period {:key, {:key_dot, @key_pressed, []}}
       @bang {:key, {:key_1, @key_pressed, [:shift]}}
       @question_mark {:key, {:key_slash, @key_pressed, [:shift]}}
-      @ampersand {:key, {:key_2, @key_pressed, [:shift]}}
+      @asperand {:key, {:key_2, @key_pressed, [:shift]}}
       @colon {:key, {:key_semicolon, @key_pressed, [:shift]}}
       @comma {:key, {:key_comma, @key_pressed, []}}
       @quote_character {:key, {:key_apostrophe, @key_pressed, [:shift]}}
@@ -220,7 +220,7 @@ defmodule ScenicWidgets.ScenicEventsDefinitions do
         @right_parenthesis,
         @left_brace,
         @right_brace,
-        @ampersand,
+        @asperand,
         @minus_sign,
         @apostrophe
       ]
@@ -311,7 +311,7 @@ defmodule ScenicWidgets.ScenicEventsDefinitions do
 
       def key2string(@period), do: "."
       def key2string(@bang), do: "!"
-      def key2string(@ampersand), do: "@"
+      def key2string(@asperand), do: "@"
       def key2string(@question_mark), do: "?"
       def key2string(@colon), do: ":"
       def key2string(@comma), do: ","

--- a/lib/core/scenic_events_definitions.ex
+++ b/lib/core/scenic_events_definitions.ex
@@ -192,7 +192,7 @@ defmodule ScenicWidgets.ScenicEventsDefinitions do
       @period {:key, {:key_dot, @key_pressed, []}}
       @bang {:key, {:key_1, @key_pressed, [:shift]}}
       @question_mark {:key, {:key_slash, @key_pressed, [:shift]}}
-      @asperand {:key, {:key_2, @key_pressed, [:shift]}}
+      @ampersand {:key, {:key_2, @key_pressed, [:shift]}}
       @colon {:key, {:key_semicolon, @key_pressed, [:shift]}}
       @comma {:key, {:key_comma, @key_pressed, []}}
       @quote_character {:key, {:key_apostrophe, @key_pressed, [:shift]}}
@@ -220,7 +220,7 @@ defmodule ScenicWidgets.ScenicEventsDefinitions do
         @right_parenthesis,
         @left_brace,
         @right_brace,
-        @asperand,
+        @ampersand,
         @minus_sign,
         @apostrophe
       ]
@@ -311,7 +311,7 @@ defmodule ScenicWidgets.ScenicEventsDefinitions do
 
       def key2string(@period), do: "."
       def key2string(@bang), do: "!"
-      def key2string(@asperand), do: "@"
+      def key2string(@ampersand), do: "@"
       def key2string(@question_mark), do: "?"
       def key2string(@colon), do: ":"
       def key2string(@comma), do: ","


### PR DESCRIPTION
Mostly formatting, spelling suggestions, and error checking.

This error was not very helpful:

<details>
  <summary>** (CaseClauseError) no case clause matching: ...</summary>

  ```
  [error] GenServer #PID<0.450.0> terminating
  ** (CaseClauseError) no case clause matching: %{metrics: %FontMetrics{ascent: 1900, descent: -500, direction: 2, kerning: %{}, line_gap: 0, max_box: {-1509, -555, 2352, 2163}, metrics: %{33 => 527, 168 => 856, 117 => 1129, 8201 => 418, 246 => 1168, 175 => 938, 219 => 1328, 192 => 1336, 188 => 1500, 73 => 557, 44 => 402, 183 => 534, 124 => 499, 239 => 506, 170 => 915, 47 => 844, 89 => 1230, 203 => 1164, 61 => 1124, 43 => 1161, 163 => 1190, 8194 => 1044, 39 => 357, 45 => 565, 242 => 1168, 235 => 1085, 48 => 1150, 247 => 1169, 171 => 961, 197 => 1336, 8216 => 409, 57 => 1150, 8260 => 931, 8242 => 357, 237 => 506, 221 => 1230, 113 => 1164, 8212 => 1599, 225 => 1114, 69 => 1164, 88 => 1284, 250 => 1129, ...}, smallest_ppem: 9, source: %FontMetrics.Source{created_at: ~U[2008-09-12 12:29:34Z], file: "", font_type: :true_type, modified_at: ~U[2017-03-29 12:03:00Z], signature: <<11, 29, 127, 135, 243, 202, 76, 139, 75, 215, 73, 176, 43, 106, 215, 28, 147, 11, 126, 48, 108, 117, 42, 46, 34, 147, 215, 178, 80, 176, 46, 39>>, signature_type: :sha256}, units_per_em: 2048, version: "0.1.1"}, size: 36}
      (scenic_widget_contrib 0.1.0) lib/components/menu_bar/menu_bar.ex:61: ScenicWidgets.MenuBar.validate/1
      (scenic 0.11.0-beta.0) lib/scenic/primitive/component.ex:78: Scenic.Primitive.Component.validate/1
      (scenic 0.11.0-beta.0) lib/scenic/primitive.ex:179: Scenic.Primitive.build/3
      (scenic 0.11.0-beta.0) lib/scenic/graph.ex:259: Scenic.Graph.add/4
      (example 0.1.0) lib/scenes/scene.ex:46: Example.Scene.init/3
      (scenic 0.11.0-beta.0) lib/scenic/scene.ex:1327: Scenic.Scene.handle_continue/2
      (stdlib 4.0.1) gen_server.erl:1120: :gen_server.try_dispatch/4
      (stdlib 4.0.1) gen_server.erl:862: :gen_server.loop/7
  Last message: {:continue, {:_init, [supervisor: #PID<0.442.0>, stop_pid: #PID<0.442.0>, child_supervisor: nil, name: "_main_", module: Example.Scene, parent: #PID<0.411.0>, param: nil, viewport: %Scenic.ViewPort{name: :main_viewport, pid: #PID<0.411.0>, script_table: #Reference<0.2254774182.1087766536.217401>, size: {800, 600}}, root_sup: #PID<0.413.0>, opts: [theme: :dark]]}}
  State: nil
  ```
</details>

The new error is more descriptive (although still very long!):

<details>
  <summary>** (RuntimeError) MenuBar: Invalid font received. Should either be an atom representing a font name or a map with `:name`, `:size`, and optionally `:metrics`.</summary>

  ```
  [error] GenServer #PID<0.450.0> terminating
  ** (RuntimeError) MenuBar: Invalid font received. Should either be an atom representing a font name or a map with `:name`, `:size`, and optionally `:metrics`. (received: %{
    metrics: %FontMetrics{
      ascent: 1900,
      descent: -500,
      direction: 2,
      kerning: %{},
      line_gap: 0,
      max_box: {-1509, -555, 2352, 2163},
      metrics: %{
        33 => 527,
        168 => 856,
        117 => 1129,
        8201 => 418,
        246 => 1168,
        175 => 938,
        219 => 1328,
        192 => 1336,
        188 => 1500,
        73 => 557,
        44 => 402,
        183 => 534,
        124 => 499,
        239 => 506,
        170 => 915,
        47 => 844,
        89 => 1230,
        203 => 1164,
        61 => 1124,
        43 => 1161,
        163 => 1190,
        8194 => 1044,
        39 => 357,
        45 => 565,
        242 => 1168,
        235 => 1085,
        48 => 1150,
        247 => 1169,
        171 => 961,
        197 => 1336,
        8216 => 409,
        57 => 1150,
        8260 => 931,
        8242 => 357,
        237 => 506,
        221 => 1230,
        113 => 1164,
        8212 => 1599,
        225 => 1114,
        69 => 1164,
        88 => 1284,
        250 => 1129,
        ...
      },
      smallest_ppem: 9,
      source: %FontMetrics.Source{
        created_at: ~U[2008-09-12 12:29:34Z],
        file: "",
        font_type: :true_type,
        modified_at: ~U[2017-03-29 12:03:00Z],
        signature: <<11, 29, 127, 135, 243, 202, 76, 139, 75, 215, 73, 176, 43,
          106, 215, 28, 147, 11, 126, 48, 108, 117, 42, 46, 34, 147, 215, 178, 80,
          176, 46, 39>>,
        signature_type: :sha256
      },
      units_per_em: 2048,
      version: "0.1.1"
    },
    size: 36
  })
      (scenic_widget_contrib 0.1.0) lib/components/menu_bar/menu_bar.ex:78: ScenicWidgets.MenuBar.validate/1
      (scenic 0.11.0-beta.0) lib/scenic/primitive/component.ex:78: Scenic.Primitive.Component.validate/1
      (scenic 0.11.0-beta.0) lib/scenic/primitive.ex:179: Scenic.Primitive.build/3
      (scenic 0.11.0-beta.0) lib/scenic/graph.ex:259: Scenic.Graph.add/4
      (example 0.1.0) lib/scenes/scene.ex:46: Example.Scene.init/3
      (scenic 0.11.0-beta.0) lib/scenic/scene.ex:1327: Scenic.Scene.handle_continue/2
      (stdlib 4.0.1) gen_server.erl:1120: :gen_server.try_dispatch/4
      (stdlib 4.0.1) gen_server.erl:862: :gen_server.loop/7
  Last message: {:continue, {:_init, [supervisor: #PID<0.442.0>, stop_pid: #PID<0.442.0>, child_supervisor: nil, name: "_main_", module: Example.Scene, parent: #PID<0.411.0>, param: nil, viewport: %Scenic.ViewPort{name: :main_viewport, pid: #PID<0.411.0>, script_table: #Reference<0.3234912335.2162819077.187031>, size: {800, 600}}, root_sup: #PID<0.413.0>, opts: [theme: :dark]]}}
  State: nil
  ```
</details>