### PR TITLE
Re-add ScenicWidgets.Utils.wrap_and_shorten_text/5

### DIFF
--- a/lib/core/utils/utils.ex
+++ b/lib/core/utils/utils.ex
@@ -10,4 +10,39 @@ defmodule ScenicWidgets.Utils do
     # to calculate if we're inside the bounds
     x >= left and x <= right and (y >= top and y <= bottom)
   end
+
+  @doc """
+  Wrap and shorten text to a set number of lines
+
+    iex> {:ok, {_type, fm}} = Scenic.Assets.Static.meta(:roboto)
+    iex> line_width = 130
+    iex> num_lines = 2
+    iex> font_size = 16
+    iex> wrap_and_shorten_text("Some text that needs to be wrapped and shortened", line_width, num_lines, font_size, fm)
+    "Some text that
+    needs to be wra…"
+  """
+  def wrap_and_shorten_text(text, line_width, num_lines, font_size, font_metrics) do
+    text =
+      text
+      |> FontMetrics.shorten(line_width * num_lines, font_size, font_metrics)
+      |> FontMetrics.wrap(line_width, font_size, font_metrics)
+
+    lines = String.split(text, "\n")
+
+    if length(lines) > num_lines do
+      List.flatten([
+        Enum.slice(lines, 0..(num_lines - 2)),
+        # Join the last two lines and re-shorten it (the wrapping may have
+        # introduced an extra line)
+        Enum.slice(lines, (num_lines - 1)..-1)
+        |> Enum.join(" ")
+        |> FontMetrics.shorten(line_width, font_size, font_metrics)
+      ])
+      |> Enum.join("\n")
+    else
+      text
+    end
+  end
+
 end

--- a/lib/core/utils/utils.ex
+++ b/lib/core/utils/utils.ex
@@ -44,5 +44,4 @@ defmodule ScenicWidgets.Utils do
       text
     end
   end
-
 end


### PR DESCRIPTION
It was accidentally removed/not replaced when `ScenicWidgets.Utils` was moved in https://github.com/scenic-contrib/scenic-widget-contrib/pull/16/files#diff-6aac06af3103fe2ea1c45d52cacca2f3029828b47bfc92fbc337dedfb82890bf